### PR TITLE
Use erreur_L2 in convergence analysis

### DIFF
--- a/cylinder_flow.py
+++ b/cylinder_flow.py
@@ -429,7 +429,7 @@ def analyse_convergence(tailles_maillage, U_inf, R, R_ext):
 
         # --- Référence + erreur
         psi_ref = solution_analytique(U_inf, r, theta, R)
-        erreurs[i]   = np.sqrt(np.sum((psi - psi_ref)**2))   # √Σ e^2
+        erreurs[i] = erreur_L2(psi, psi_ref)
         nb_points[i] = nr * ntheta
 
 #       print(f"Erreur L2 : {erreur:.2e} | Temps : {duree:.2f}s")


### PR DESCRIPTION
## Summary
- Simplify convergence analysis by reusing existing `erreur_L2` function to compute L2 error

## Testing
- `python -m py_compile cylinder_flow.py`
- `python - <<'PY'
from cylinder_flow import analyse_convergence
U_inf=10
R=3
R_ext=10
tailles_maillage=[(10, 20)]
nb_points, erreurs, temps = analyse_convergence(tailles_maillage, U_inf, R, R_ext)
print('nb_points:', nb_points)
print('erreurs:', erreurs)
print('temps:', temps)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689b5e9bb8e483338bb36cc256c1cdb1