### PR TITLE
Document functions and clarify main workflow

### DIFF
--- a/cylinder_flow.py
+++ b/cylinder_flow.py
@@ -213,21 +213,55 @@ def calculer_vitesses(psi, r, theta, dr, dtheta):
 
 
 def tracer_cartes_vx_vy(u, v, r, theta, R,
-                        niveaux=300, cmap='coolwarm', 
-                        ranges=((0.0, 1.75), (-0.75, 0.75)), 
+                        niveaux=300, cmap='coolwarm',
+                        ranges=((0.0, 1.75), (-0.75, 0.75)),
                         fichier="Figures/vx_vy.png"):
+    """Trace les cartes de vitesse cartésienne ``v_x`` et ``v_y``.
 
-    # grille polaire
+    Parameters
+    ----------
+    u : numpy.ndarray
+        Composante cartésienne ``x`` de la vitesse (m/s).
+    v : numpy.ndarray
+        Composante cartésienne ``y`` de la vitesse (m/s).
+    r : numpy.ndarray
+        Coordonnées radiales (m).
+    theta : numpy.ndarray
+        Coordonnées angulaires (rad).
+    R : float
+        Rayon du cylindre (m).
+    niveaux : int, optional
+        Nombre de niveaux de contours pour les cartes, par défaut ``300``.
+    cmap : str or matplotlib.colors.Colormap, optional
+        Carte de couleurs utilisée, par défaut ``'coolwarm'``.
+    ranges : tuple of tuple of float, optional
+        Intervalles ``((vx_min, vx_max), (vy_min, vy_max))`` pour les
+        composantes ``v_x`` et ``v_y`` en m/s.
+    fichier : str or None, optional
+        Chemin de sauvegarde de la figure. Aucun fichier n'est créé si ``None``.
+
+    Returns
+    -------
+    None
+        La fonction génère un graphique et ne renvoie aucune valeur.
+
+    Notes
+    -----
+    Les champs à l'intérieur du cylindre sont masqués afin de ne tracer que
+    l'écoulement extérieur.
+    """
+
+    # grille polaire pour les coordonnées d'évaluation
     Rg, Tg = np.meshgrid(r, theta, indexing='ij')
-    # grille cartesienne
+    # conversion vers les coordonnées cartésiennes
     X, Y = Rg*np.cos(Tg), Rg*np.sin(Tg)
 
-    # champs à tracer
+    # masque les points situés à l'intérieur du cylindre
     mask = Rg <= R
     u_plot = np.ma.array(u, mask=mask)
     v_plot = np.ma.array(v, mask=mask)
 
-    # périodicité : répète la première colonne en fin
+    # périodicité : répète la première colonne pour fermer l'anneau
     Xw = np.concatenate([X, X[:, :1]], axis=1)
     Yw = np.concatenate([Y, Y[:, :1]], axis=1)
     Uw = np.ma.concatenate([u_plot, u_plot[:, :1]], axis=1)
@@ -237,6 +271,7 @@ def tracer_cartes_vx_vy(u, v, r, theta, R,
     levels_u = np.linspace(vx_min, vx_max, niveaux)
     levels_v = np.linspace(vy_min, vy_max, niveaux)
 
+    # création des deux sous-graphiques côte à côte
     fig, axs = plt.subplots(1, 2, figsize=(12,5), constrained_layout=True)
     im0 = axs[0].contourf(Xw, Yw, Uw, levels=levels_u, cmap=cmap, extend='both')
     im1 = axs[1].contourf(Xw, Yw, Vw, levels=levels_v, cmap=cmap, extend='both')
@@ -250,13 +285,13 @@ def tracer_cartes_vx_vy(u, v, r, theta, R,
 
     axs[0].set_title(r"$v_x$ Component", fontsize=16, pad=8)
     axs[1].set_title(r"$v_y$ Component", fontsize=16, pad=8)
-    
-    # vx : ticks 0.00 → 1.75
+
+    # barre de couleur pour v_x : ticks 0.00 → 1.75
     c0 = fig.colorbar(im0, ax=axs[0], ticks=np.linspace(vx_min, vx_max, 8))
     c0.set_label(r"$v_x$", fontsize=14)
     c0.formatter = FormatStrFormatter("%.2f"); c0.update_ticks()
 
-    # vy : ticks -0.75 → 0.75 avec 0 centré
+    # barre de couleur pour v_y : ticks -0.75 → 0.75 avec 0 centré
     c1 = fig.colorbar(im1, ax=axs[1], ticks=np.linspace(vy_min, vy_max, 7))
     c1.set_label(r"$v_y$", fontsize=14)
     c1.formatter = FormatStrFormatter("%.2f"); c1.update_ticks()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import numpy as np
-from cylinder_flow import ( 
+from cylinder_flow import (
     creer_maillage,
     construire_matrice_systeme,
     resoudre_laplace,
@@ -12,23 +12,42 @@ from cylinder_flow import (
     tracer_cartes_vx_vy,
     analyse_convergence,
     tracer_convergence,
-    seq_maillages
+    seq_maillages,
 )
 
 
-if __name__ == "__main__":
+def main():
+    """Exécute la simulation d'écoulement autour d'un cylindre.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    None
+        La fonction ne renvoie aucune valeur mais génère des figures
+        et affiche les résultats numériques.
+
+    Notes
+    -----
+    Les paramètres physiques ``U_inf`` (m/s), ``R`` (m) et ``R_ext`` (m)
+    sont définis directement dans la fonction.
+    """
+
     # Paramètres du problème donnés
-    U_inf = 10
-    R = 3
-    R_ext = 10
+    U_inf = 10  # vitesse uniforme à l'infini (m/s)
+    R = 3       # rayon du cylindre (m)
+    R_ext = 10  # rayon extérieur du domaine (m)
 
     # Résolution pour le maillage choisi
     print("=== Résolution du problème ===")
-    r, theta, dr, dtheta = creer_maillage(R, R_ext, 50, 80) # création maillage polaire
+    # création du maillage polaire
+    r, theta, dr, dtheta = creer_maillage(R, R_ext, 50, 80)
     A, b = construire_matrice_systeme(r, theta, dr, dtheta, U_inf, R, R_ext)
     psi = resoudre_laplace(A, b, len(r), len(theta))
     vr, vtheta, u, v = calculer_vitesses(psi, r, theta, dr, dtheta)
-    u_n, v_n = u / U_inf, v / U_inf
+    u_n, v_n = u / U_inf, v / U_inf  # vitesses normalisées
     tracer_cartes_vx_vy(u_n, v_n, r, theta, R)
 
     # Vérification avec la solution exacte
@@ -43,12 +62,17 @@ if __name__ == "__main__":
     tracer_lignes_courant(psi, r, theta, R)
     tracer_champ_vitesse(u, v, r, theta, R)
 
-    #Analyse de la convergence
+    # Analyse de la convergence
     print("\n=== Analyse de convergence ===")
     tailles_maillage = seq_maillages()
     print(tailles_maillage)
-    nb_points, erreurs, temps = analyse_convergence(tailles_maillage, U_inf, R, R_ext) #calcul L2, temps total, nombre de points
-    
+    # calcul L2, temps total et nombre de points
+    nb_points, erreurs, temps = analyse_convergence(tailles_maillage, U_inf, R, R_ext)
+
     eoc = np.log(erreurs[1:] / erreurs[:-1]) / np.log(nb_points[1:] / nb_points[:-1])
     print("EOC attendu ≈ -0.50 :", eoc)
     tracer_convergence(nb_points, erreurs, temps)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document `tracer_cartes_vx_vy` with parameters, returns and detailed notes
- wrap script logic into a documented `main` function with clarifying comments

## Testing
- `python -m py_compile cylinder_flow.py main.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_689d428d51dc83338200b1e72edaf4ca